### PR TITLE
Implement Client#delete

### DIFF
--- a/lib/sony_ci_api/client.rb
+++ b/lib/sony_ci_api/client.rb
@@ -74,7 +74,9 @@ module SonyCiApi
       send_request(:put, path, params: params, headers: headers)
     end
 
-    def delete(path, params: {}); end        # TODO
+    def delete(path, params: {}, headers: {})
+      send_request(:delete, path, params: params, headers: headers)
+    end
 
     def access_token
       @access_token ||= begin


### PR DESCRIPTION
SonyCiApi::Client#delete works similar to companion methods #get, #post, and #put; a pass-through method
to allow making any DELETE request that the actual Sony Ci API supports.

Closes #3.