### PR TITLE
Allows different streaming types

### DIFF
--- a/lib/sony_ci_api/client.rb
+++ b/lib/sony_ci_api/client.rb
@@ -144,11 +144,13 @@ module SonyCiApi
       get "/assets/#{asset_id}/download"
     end
 
-    def asset_stream_hls_url(asset_id)
+    def asset_stream_url(asset_id, type: "hls")
+      type = type.downcase
+      raise ArgumentError, "Invalid value for parameter type. Expected one of hls, video-3g, or video-sd, but '#{type}' was given" unless %w(hls video-3g video-sd).include?(type)
       stream_name = "#{asset_id}-stream"
       expire_date = DateTime.now.next_day.iso8601
       resp = post("/assets/#{asset_id}/streams", params: { streams: [ {name: stream_name, expirationDate: expire_date } ] }, headers: { "Content-Type" => "application/json" })
-      resp["complete"].first["streams"].find {|s| s["type"] == "hls" }["url"] if resp && resp["complete"]
+      resp["complete"].first["streams"].find {|s| s["type"] == type }["url"] if resp && resp["complete"]
     end
 
     def workspace_contents( workspace_id = self.workspace_id, **params )

--- a/spec/sony_ci_api/client_spec.rb
+++ b/spec/sony_ci_api/client_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe SonyCiApi::Client do
               "streams" => [
                 {
                   "method" => "adaptive",
-                  "type" => "hls",
+                  "type" => stream_type,
                   "url" => streaming_url,
                   "displayName" => "stream1"
                 }
@@ -457,7 +457,7 @@ RSpec.describe SonyCiApi::Client do
         }
       }
 
-      let(:asset_stream_hls_url) {
+      let(:asset_stream_url) {
         stub_request_and_call_block(
           :post,
           "#{base_url}/assets/#{asset_id}/streams",
@@ -467,13 +467,38 @@ RSpec.describe SonyCiApi::Client do
           }
         ) do
           # Call the method under test
-          client.asset_stream_hls_url(asset_id)
+          client.asset_stream_url(asset_id, type: stream_type)
         end
       }
 
-      it 'returns an HLS streaming URL for a given asset' do
-        expect(asset_stream_hls_url).to eq streaming_url
+      context 'when type=hls' do
+        let(:stream_type) { 'hls' }
+        it 'returns an HLS streaming URL for a given asset' do
+          expect(asset_stream_url).to eq streaming_url
+        end
       end
+
+      context 'when type=sd' do
+        let(:stream_type) { 'video-sd' }
+        it 'returns an SD streaming URL for a given asset' do
+          expect(asset_stream_url).to eq streaming_url
+        end
+      end
+
+      context 'when type=3g' do
+        let(:stream_type) { 'video-3g' }
+        it 'returns an 3G streaming URL for a given asset' do
+          expect(asset_stream_url).to eq streaming_url
+        end
+      end
+
+      context 'when type is invalid' do
+        let(:stream_type) { 'something_invalid' }
+        it 'raises an ArgumentError' do
+          expect { asset_stream_url }.to raise_error ArgumentError
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
* Changes SonyCiApi::Client#asset_stream_hls_url to SonyCiapi::Client#asset_stream_url.
* Allows a 'type' param to be 'hls', 'sd', or '3g'.